### PR TITLE
esp32 on mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ replacing `TBeam` with the board name of your device (see Supported Devices).
 
 
 ## Troubleshooting
-### Identify your serial port
-The Makefile looks for all "known" variants of device names that show up.  If your system creates a serial port name that we haven't seen then there will likely be problems.
+### Unable to detect serial port
+The Makefile looks for all "known" variants of device names that show up.  If your system does not have the correct driver installed or creates a serial port name we haven't seen yet, then there will likely be problems when flashing your device.
 
 Open up a terminal and run the following command before and after plugging in your device with an appropriate data usb cable:
 
@@ -56,7 +56,9 @@ linux
 ls /dev/ttyUSB*
 ```
 
-the new device should show up in this list. Please open a GitHub issue and give us this information and we will add it to the Makefile.
+The serial port for your device should show up in this list after you plug it in. If not, you may need to install a USB to UART driver like the one [here](https://www.silabs.com/developer-tools/usb-to-uart-bridge-vcp-drivers?tab=downloads). However, if you do see your device, please open a GitHub issue with the information you get from the `ls` command above along with your device name and we will add it to the Makefile.
+
+### Serial port If you don't see a serial port 
 
 ### Find your Arduino CLI install
 

--- a/README.md
+++ b/README.md
@@ -58,8 +58,6 @@ ls /dev/ttyUSB*
 
 The serial port for your device should show up in this list after you plug it in. If not, you may need to install a USB to UART driver like the one [here](https://www.silabs.com/developer-tools/usb-to-uart-bridge-vcp-drivers?tab=downloads). However, if you do see your device, please open a GitHub issue with the information you get from the `ls` command above along with your device name and we will add it to the Makefile.
 
-### Serial port If you don't see a serial port 
-
 ### Find your Arduino CLI install
 
 Run the following command, this may also be useful information.  If it does not find anything please see the section on installing the Arduino CLI.

--- a/loramesh/Makefile
+++ b/loramesh/Makefile
@@ -151,6 +151,8 @@ ifndef SERIAL
     SERIAL = $(shell ls /dev/tty.usbserial-????)
   else ifeq ($(BOARD),T5gray)
     SERIAL = $(shell ls /dev/tty.usbserial-???????????)
+  else ifeq ($(BOARD),TBeam)
+    SERIAL = $(shell ls /dev/tty.usbserial-???????????)
   else ifeq ($(BOARD),TDeck)
     SERIAL = $(shell ls /dev/tty.usbmodem*)
   else ifeq ($(BOARD),TWatch)
@@ -159,9 +161,9 @@ ifndef SERIAL
     SERIAL = $(shell ls /dev/tty.usbserial-???????????)
   else ifeq ($(BOARD),WLpaper) # Heltec wireless paper 1.1
     SERIAL = $(shell ls /dev/tty.usbserial-????)
-  else # T-Beam
-    SERIAL= $(shell ls /dev/tty* | grep 'ACM\|USB\|wchusb')
   endif
+
+  SERIAL ?= $(shell ls /dev/tty* | grep 'ACM\|USB\|wchusb')
 
   # ? kill any screen/miniterm program currently having the serial port open ?
   # $(foreach var,$(SERIAL), fuser -f $(var);) ...

--- a/loramesh/Makefile
+++ b/loramesh/Makefile
@@ -207,6 +207,10 @@ firmware:
 		-o ./build/$(FLASH_BIN)
 
 flash:
+  ifndef SERIAL
+    $(error ">> unable to detect serial port for device, make sure it is connected and drivers are installed")
+  endif
+
 	$(foreach var,$(SERIAL), \
 		$(ESPTOOL) \
 		--chip $(CHIP) \
@@ -217,6 +221,10 @@ flash:
 		0x10000 ./build/$(MAIN).bin)
 
 fullflash:
+  ifndef SERIAL
+    $(error ">> unable to detect serial port for device, make sure it is connected and drivers are installed")
+  endif
+
 	$(foreach var,$(SERIAL), \
 		$(ESPTOOL) \
 		--chip $(CHIP) \


### PR DESCRIPTION
Three commits:

1) on mac, the serial port is similar to T5Gray
2) without serial driver, I was getting a confusing message ("flash is up to date")
3) update README with troubleshooting information for no serial port detected

Commit #1 may not be acceptable, let me know if you want do this another change.